### PR TITLE
📝 Improve example MEML formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ A basic webpage in MEML looks like this:
 
 ```lisp
 (head
-    (title "Hello World!"))
+    (title "Hello World!")
+)
 (body
-    (p "Basic website made with MEML!"))
+    (p "Basic website made with MEML!")
+)
 ```
 
 This will normally translate to HTML like this:
@@ -74,17 +76,23 @@ While it doesn't do much for smaller websites like this, when getting into bigge
 ```lisp
 (head
     (title "navigation menu")
-    (viewport scale="1"))
+    (viewport scale="1")
+)
 (body
-    (nav type="full-width, flexbox")
+    (nav type="full-width, flexbox"
         (fbsplit
-            (img src="logo.png"))
+            (img src="logo.png")
+        )
         (fbsplit
             (dropdown "dropdown" method="click"
                 (dditem "option 1" href="#")
                 (dditem "option 2" href="#")
-                (dditem "option 3" href="#"))
-            (a "A button" type="button" border-radius="2rem" color="white" bgcolor="black" :hover.bgcolor="#333" href="#")))
+                (dditem "option 3" href="#")
+            )
+            (a "A button" type="button" border-radius="2rem" color="white" bgcolor="black" :hover.bgcolor="#333" href="#")
+        )
+    )
+)
 ```
 
 The HTML translation:


### PR DESCRIPTION
Whilst I have limited experience with LISP, I personally believe that this way of formatting MEML makes more sense. As meml is a structured language, it makes more sense to put everything in a tree:
```lisp 
(body
    (h1 "Hello world")
    (div
        (h2 "Some math")
        (p "2 + 2 =" 2 + 2)
        (p "2 × 2 =" 2 * 2)
     )
)
```
Than to close the tag immediately: 
```lisp 
(body
    (h1 "Hello world")
    (div
        (h2 "Some math")
        (p "2 + 2 =" 2 + 2)
        (p "2 × 2 =" 2 * 2)))
```
