### PR TITLE
📝 Add components and import/export

### DIFF
--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -13,13 +13,16 @@ Again, the language grammar here is based off of that for lox. Here page is a pr
 //             passthrough, should it be limited to inside
 //             custom tags, should it be LISP or should it
 //             be something more c-like (or python-like)
-page        = statement* EOF;
+page        = declaration* EOF;
+
+// For declaring stuff like constants or components
+declaration = compDecl
+            | statement;
 
 // This will contain all of the major logic, for the moment
 // it only accepts meml statements, but that will change once
 // scripting is being planned
-statement   = compntStmt
-            | memlStmt
+statement   = memlStmt
             | expression;
 
 // This is how components should be defined. The MEML interpreter must
@@ -27,7 +30,7 @@ statement   = compntStmt
 // if it cannot find the correct tag as part of `memlStmt`. The destructure
 // here is for passing in props that will be used and the identifier
 // is the tag name.
-compntStmt  = '(' 'component' IDENTIFIER destructure? statement ')';
+compDecl    = '(' 'component' IDENTIFIER destructure? statement ')';
 
 // This is what a meml tag will look like. Note that there
 // can be as many expressions as is

--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -39,45 +39,34 @@ memlStmt    = '(' IDENTIFIER memlProp* statement* ')';
 memlProp    =  IDENTIFIER
             | IDENTIFIER '=' expression;
 
-// Doing math, boolean logic or combining strings and such
-// Contains additional types
-expression  = literal
-            | unary
-            | binary
-            | destructure
-            | grouping;
 
-// Contains all of the raw data types.
-literal     = NUMBER
-            | STRING
-            | 'true'
-            | 'false'
-            | 'null';
+expression  = equality;
+
+// Check if something is equal
+equality    = comparison (('!=' | '==') comparison)*;
+
+// Check how one value compares to anther
+comparison  = term (('>' | '>=' | '<' | '<=') term)*;
+
+// Addition or subtraction
+term        = factor (('-' | '+') factor)*;
+
+// Multiplication and division
+factor      = unary (('/' | '*') unary)*;
 
 // Used to negate or invert a value
-unary       = ('-' | '!') expression;
+unary       = ('!' | '-') unary
+            | primary;
 
-// This is your standard something + something or a boolean
-// comparison. Please note the order of operations with
-// * and / having priority over + and -
-binary      = expression operator expression;
-
-// Everything inside of the grouping takes precedence to
-// everything outside
-grouping    = '(' expression ')';
+// Very basic stuff
+primary     = NUMBER | STRING | 'true' | 'false' | 'null'
+            | '(' expression ')';
 
 // When you need to pass paramaters into a function or
 // component, you would use a destructure expression.
 // They only take in identifiers and WILL NOT take in
 // literals
 destructure = '(' IDENTIFIER* ')';
-
-// All of the different operators that you should want
-//
-// DISCUSSION: Should we include === or does that just
-//             need to die
-operator    = "==" | "!=" | "<" | "<=" | ">" | ">="
-            | "+"  | "-"  | "*" | "/" ;
 ```
 
 ## Appendix 1: Grammar reference

--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -4,7 +4,7 @@ This provides implementation details for the meml syntax. For an introduction to
 
 ## Language grammar
 
-Again, the language grammer here is based off of that for lox. Here page is a program. It contains everything in a file.
+Again, the language grammar here is based off of that for lox. Here page is a program. It contains everything in a file.
 
 ```ts
 // This is the entry point into the program (a single file).
@@ -18,7 +18,15 @@ page        = statement* EOF;
 // This will contain all of the major logic, for the moment
 // it only accepts meml statements, but that will change once
 // scripting is being planned
-statement   = memlStmt;
+statement   = compntStmt
+            | memlStmt;
+
+// This is how components should be defined. The MEML interpreter must
+// keep a log of all of the components defined and search through them
+// if it cannot find the correct tag as part of `memlStmt`. The destructure
+// here is for passing in props that will be used and the identifier
+// is the tag name.
+compntStmt  = '(' 'component' IDENTIFIER destructure? exprOrMeml ')';
 
 // This is what a meml tag will look like. Note that there
 // can be as many expressions as is
@@ -36,9 +44,11 @@ exprOrMeml  = memlStmt
             | expression;
 
 // Doing math, boolean logic or combining strings and such
+// Contains additional types
 expression  = literal
             | unary
             | binary
+            | destructure
             | grouping;
 
 // Contains all of the raw data types.
@@ -59,6 +69,12 @@ binary      = expression operator expression;
 // Everything inside of the grouping takes precedence to
 // everything outside
 grouping    = '(' expression ')';
+
+// When you need to pass paramaters into a function or
+// component, you would use a destructure expression.
+// They only take in identifiers and WILL NOT take in
+// literals
+destructure = '(' IDENTIFIER* ')';
 
 // All of the different operators that you should want
 //
@@ -82,6 +98,7 @@ Here is a nice cheat sheet for all of the symbols:
 - `|`: Or, the item that comes first takes precedence
 - `;`: End of this line
 - `*`: None, one, or multiple
+- `?`: None or one (optional)
 - `(...)`: Grouping, everything inside is calculated to form one answer outside
 
 Additionally, here is a cheat sheet of types and tokens. Typescript types are used because they are the limitation we are bound with when working with web technologies.

--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -30,7 +30,7 @@ statement   = memlStmt
 // if it cannot find the correct tag as part of `memlStmt`. The destructure
 // here is for passing in props that will be used and the identifier
 // is the tag name.
-compDecl    = 'component' IDENTIFIER '(' destructure ')' '(' statement ')';
+compDecl    = 'component' IDENTIFIER '(' destructure ')' '(' memlStmt ')';
 
 // This is what a meml tag will look like. Note that there
 // can be as many expressions as is

--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -13,7 +13,7 @@ Again, the language grammar here is based off of that for lox. Here page is a pr
 //             passthrough, should it be limited to inside
 //             custom tags, should it be LISP or should it
 //             be something more c-like (or python-like)
-page        = ('(' declaration ')')* EOF;
+page        = declaration* EOF;
 
 // For declaring stuff like constants or components
 declaration = compDecl
@@ -30,11 +30,11 @@ statement   = memlStmt
 // if it cannot find the correct tag as part of `memlStmt`. The destructure
 // here is for passing in props that will be used and the identifier
 // is the tag name.
-compDecl    = 'component' IDENTIFIER '(' destructure ')' '(' memlStmt ')';
+compDecl    = '(' 'component' IDENTIFIER '(' destructure ')' memlStmt ')';
 
 // This is what a meml tag will look like. Note that there
 // can be as many expressions as is
-memlStmt    = IDENTIFIER memlProp* statement*;
+memlStmt    = '(' IDENTIFIER memlProp* statement* ')';
 
 // This is the layout for the properties of a meml tag. It
 // can either be a key-value pair or a key pair (for example

--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -13,58 +13,58 @@ Again, the language grammer here is based off of that for lox. Here page is a pr
 //             passthrough, should it be limited to inside
 //             custom tags, should it be LISP or should it
 //             be something more c-like (or python-like)
-page        → statement* EOF;
+page        = statement* EOF;
 
 // This will contain all of the major logic, for the moment
 // it only accepts meml statements, but that will change once
 // scripting is being planned
-statement   → memlStmt;
+statement   = memlStmt;
 
 // This is what a meml tag will look like. Note that there
 // can be as many expressions as is
-memlStmt    → '(' IDENTIFIER memlProp* exprOrMeml* ')';
+memlStmt    = '(' IDENTIFIER memlProp* exprOrMeml* ')';
 
 // This is the layout for the properties of a meml tag. It
 // can either be a key-value pair or a key pair (for example
 // `disabled`)
-memlProp    →  IDENTIFIER
+memlProp    =  IDENTIFIER
             | IDENTIFIER '=' expression;
 
 // Expression statements and meml can be used interchangeably
 // within a tag
-exprOrMeml  → memlStmt
+exprOrMeml  = memlStmt
             | expression;
 
 // Doing math, boolean logic or combining strings and such
-expression  → literal
+expression  = literal
             | unary
             | binary
             | grouping;
 
 // Contains all of the raw data types.
-literal     → NUMBER
+literal     = NUMBER
             | STRING
             | 'true'
             | 'false'
             | 'null';
 
 // Used to negate or invert a value
-unary       → ('-' | '!') expression;
+unary       = ('-' | '!') expression;
 
 // This is your standard something + something or a boolean
 // comparison. Please note the order of operations with
 // * and / having priority over + and -
-binary      → expression operator expression;
+binary      = expression operator expression;
 
 // Everything inside of the grouping takes precedence to
 // everything outside
-grouping    → '(' expression ')';
+grouping    = '(' expression ')';
 
 // All of the different operators that you should want
 //
 // DISCUSSION: Should we include === or does that just
 //             need to die
-operator    → "==" | "!=" | "<" | "<=" | ">" | ">="
+operator    = "==" | "!=" | "<" | "<=" | ">" | ">="
             | "+"  | "-"  | "*" | "/" ;
 ```
 
@@ -78,7 +78,7 @@ Identifier → What that identifier consists of
 
 Here is a nice cheat sheet for all of the symbols:
 
-- `→`: Separator
+- `=`: Separator
 - `|`: Or, the item that comes first takes precedence
 - `;`: End of this line
 - `*`: None, one, or multiple

--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -13,7 +13,7 @@ Again, the language grammar here is based off of that for lox. Here page is a pr
 //             passthrough, should it be limited to inside
 //             custom tags, should it be LISP or should it
 //             be something more c-like (or python-like)
-page        = declaration* EOF;
+page        = ('(' declaration ')')* EOF;
 
 // For declaring stuff like constants or components
 declaration = compDecl
@@ -30,11 +30,11 @@ statement   = memlStmt
 // if it cannot find the correct tag as part of `memlStmt`. The destructure
 // here is for passing in props that will be used and the identifier
 // is the tag name.
-compDecl    = '(' 'component' IDENTIFIER destructure? statement ')';
+compDecl    = 'component' IDENTIFIER destructure? statement;
 
 // This is what a meml tag will look like. Note that there
 // can be as many expressions as is
-memlStmt    = '(' IDENTIFIER memlProp* statement* ')';
+memlStmt    = IDENTIFIER memlProp* statement*;
 
 // This is the layout for the properties of a meml tag. It
 // can either be a key-value pair or a key pair (for example

--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -30,7 +30,7 @@ statement   = memlStmt
 // if it cannot find the correct tag as part of `memlStmt`. The destructure
 // here is for passing in props that will be used and the identifier
 // is the tag name.
-compDecl    = 'component' IDENTIFIER ('(' destructure ')')? '(' statement ')';
+compDecl    = 'component' IDENTIFIER '(' destructure ')' '(' statement ')';
 
 // This is what a meml tag will look like. Note that there
 // can be as many expressions as is

--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -4,19 +4,13 @@ This provides implementation details for the meml syntax. For an introduction to
 
 ## Language grammar
 
-Again, the language grammar here is based off of that for lox. Here page is a program. It contains everything in a file.
-
 ```ts
 // This is the entry point into the program (a single file).
-//
-// DISCUSSION: How should scripting work? Should it be JS
-//             passthrough, should it be limited to inside
-//             custom tags, should it be LISP or should it
-//             be something more c-like (or python-like)
 page        = declaration* EOF;
 
 // For declaring stuff like constants or components
 declaration = compDecl
+            | exportDecl
             | statement;
 
 // This will contain all of the major logic, for the moment
@@ -31,6 +25,17 @@ statement   = memlStmt
 // here is for passing in props that will be used and the identifier
 // is the tag name.
 compDecl    = '(' 'component' IDENTIFIER '(' destructure ')' memlStmt ')';
+
+// This is how exports should be defined. Please limit this to one export
+// statement where possible. You may decide to implement support for multiple
+// but provide linter warnings of some kind just to keep meml code easier to read
+exportDecl  = '(' 'export' '(' destructure ')' ')';
+
+// Import statements should have a structure like this. You can either specify what you
+// want to import from specific exports or everything from a file. Additionally, for
+// css and js files, you can dump them into the current meml file with the command
+// (import "./file.(css|js)")
+importStmt  = '(' 'import' ((('(' destructure ')') | 'everything') 'from')? STRING ')'
 
 // This is what a meml tag will look like. Note that there
 // can be as many expressions as is
@@ -68,7 +73,7 @@ primary     = NUMBER | STRING | 'true' | 'false' | 'null'
 // Identifier types are used specifically for variable declaration etc.
 identifier  = IDENTIFIER;
 
-// When you need to pass paramaters into a function or
+// When you need to pass parameters into a function or
 // component, you would use a destructure expression.
 // They only take in identifiers and WILL NOT take in
 // literals

--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -19,29 +19,25 @@ page        = statement* EOF;
 // it only accepts meml statements, but that will change once
 // scripting is being planned
 statement   = compntStmt
-            | memlStmt;
+            | memlStmt
+            | expression;
 
 // This is how components should be defined. The MEML interpreter must
 // keep a log of all of the components defined and search through them
 // if it cannot find the correct tag as part of `memlStmt`. The destructure
 // here is for passing in props that will be used and the identifier
 // is the tag name.
-compntStmt  = '(' 'component' IDENTIFIER destructure? exprOrMeml ')';
+compntStmt  = '(' 'component' IDENTIFIER destructure? statement ')';
 
 // This is what a meml tag will look like. Note that there
 // can be as many expressions as is
-memlStmt    = '(' IDENTIFIER memlProp* exprOrMeml* ')';
+memlStmt    = '(' IDENTIFIER memlProp* statement* ')';
 
 // This is the layout for the properties of a meml tag. It
 // can either be a key-value pair or a key pair (for example
 // `disabled`)
 memlProp    =  IDENTIFIER
             | IDENTIFIER '=' expression;
-
-// Expression statements and meml can be used interchangeably
-// within a tag
-exprOrMeml  = memlStmt
-            | expression;
 
 // Doing math, boolean logic or combining strings and such
 // Contains additional types

--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -30,7 +30,7 @@ statement   = memlStmt
 // if it cannot find the correct tag as part of `memlStmt`. The destructure
 // here is for passing in props that will be used and the identifier
 // is the tag name.
-compDecl    = 'component' IDENTIFIER destructure? statement;
+compDecl    = 'component' IDENTIFIER ('(' destructure ')')? '(' statement ')';
 
 // This is what a meml tag will look like. Note that there
 // can be as many expressions as is
@@ -39,7 +39,7 @@ memlStmt    = IDENTIFIER memlProp* statement*;
 // This is the layout for the properties of a meml tag. It
 // can either be a key-value pair or a key pair (for example
 // `disabled`)
-memlProp    =  IDENTIFIER
+memlProp    = IDENTIFIER
             | IDENTIFIER '=' expression;
 
 
@@ -69,7 +69,7 @@ primary     = NUMBER | STRING | 'true' | 'false' | 'null'
 // component, you would use a destructure expression.
 // They only take in identifiers and WILL NOT take in
 // literals
-destructure = '(' IDENTIFIER* ')';
+destructure = IDENTIFIER ( ',' IDENTIFIER )*;
 ```
 
 ## Appendix 1: Grammar reference

--- a/docs/syntaxStandard.md
+++ b/docs/syntaxStandard.md
@@ -63,7 +63,10 @@ unary       = ('!' | '-') unary
 
 // Very basic stuff
 primary     = NUMBER | STRING | 'true' | 'false' | 'null'
-            | '(' expression ')';
+            | '(' expression ')' | identifier;
+
+// Identifier types are used specifically for variable declaration etc.
+identifier  = IDENTIFIER;
 
 // When you need to pass paramaters into a function or
 // component, you would use a destructure expression.


### PR DESCRIPTION
This pull request contains three major changes:
 - Clean up of expression grammar
 - Addition of the component statement
 - Addition of import/export statements

## Clean up expression grammar
The old expression grammar was rather vague, not providing a good amount of detail to how an implementation should be created. It didn't specify order of operations and it didn't match my development implementation. It has been modified to be better organized.

## Addition of component statements
One of the main issues I have with html is a lack of reusablility. If you create a nav bar, you have to copy and paste it across multiple files, making it hard to maintain. I believe this is one of the major reasons that react is used everywhere, because modern webdevs can't live without components.

```lisp
(component navBar () 
    (nav 
        (p "Nav code goes here")
    )
)

(body
    (nav)
)
```

## Addition of import/export statements
Along the same line as components, imports and exports allow to share components between pages, reducing code duplication.

`nav.meml`:
```lisp
(component navBar ()
// Your nav code here
)

(export (navBar))
```

`page1.meml`:
```lisp
(import (navBar) from "./nav.meml")

(body
    (nav)
)
```

`page2.meml`:
```lisp
(import (navBar) from "./nav.meml")

(body
    (nav)
)
```

**Sidenote:** I have also created some syntax highlighting files for [textmate](https://github.com/fushra/highlighting/blob/main/meml.tmLanguage) and [vscode](https://github.com/fushra/vscode/releases/tag/0.0.1)